### PR TITLE
fix conflict when newer lib version is loaded

### DIFF
--- a/DRList-1.0/Spells.lua
+++ b/DRList-1.0/Spells.lua
@@ -1,5 +1,10 @@
-local Lib, version = LibStub("DRList-1.0")
-if Lib.spellList and version >= 42 then return end
+local MAJOR, MINOR = "DRList-1.0", 42 -- Don't forget to change this in DRList-1.0.lua aswell!
+local Lib = LibStub(MAJOR)
+if Lib.spellListVersion and Lib.spellListVersion >= MINOR then
+    return
+end
+
+Lib.spellListVersion = MINOR
 
 if Lib.gameExpansion == "retail" then
 


### PR DESCRIPTION
I have reports of Gladdy bugging out with Diminish.

Apparently when a newer version of DRLib is loaded, `Spells.lua` will not load properly. That causes an inconsistent DRList state with errors on my end.

I think you want to load the newer version of Spells.lua when present. With the current logic, the check to skip loading is always true.

Ways to replicate: Load Gladdy-Classic-v2.20-Beta with DRList version 40 and load Diminish with DRList version 30.