### PR TITLE
Initial Cata Update

### DIFF
--- a/DRList-1.0/DRList-1.0.lua
+++ b/DRList-1.0/DRList-1.0.lua
@@ -33,6 +33,7 @@ L["RANDOM_STUNS"] = "Random stuns"
 L["OPENER_STUN"] = "Opener stuns"
 L["HORROR"] = "Horrors"
 L["SCATTERS"] = "Scatters"
+L["DRAGONS"] = GetSpellInfo(31661) or "Dragon's Breath"
 L["MIND_CONTROL"] = GetSpellInfo(605) or "Mind Control"
 L["FROST_SHOCK"] = GetSpellInfo(15089) or "Frost Shock"
 L["KIDNEY_SHOT"] = GetSpellInfo(408) or "Kidney Shot"
@@ -42,6 +43,7 @@ L["CHASTISE"] = GetSpellInfo(44041) or "Chastise"
 L["COUNTERATTACK"] = GetSpellInfo(19306) or "Counterattack"
 L["CYCLONE"] = GetSpellInfo(33786) or "Cyclone"
 L["CHARGE"] = GetSpellInfo(100) or "Charge"
+L["ENTRAPMENT"] = GetSpellInfo(64803) or "Entrapment"
 
 -- luacheck: push ignore 542
 local locale = GetLocale()
@@ -128,7 +130,14 @@ Lib.gameExpansion = ({
     [WOW_PROJECT_CLASSIC] = "classic",
     [WOW_PROJECT_BURNING_CRUSADE_CLASSIC or 5] = "tbc",
     [WOW_PROJECT_WRATH_CLASSIC or 11] = "wotlk",
-})[WOW_PROJECT_ID] or "wotlk" -- Fallback to wotlk when unknown (most likely a new classic expansion build)
+    [WOW_PROJECT_CATA_CLASSIC or 12] = "cata",
+})[WOW_PROJECT_ID] or "cata" -- Fallback to cata when unknown (most likely a new classic expansion build)
+
+-- temporary Cata beta fix because WOW_PROJECT_ID is still 11
+local _, _, _, toc = GetBuildInfo()
+if toc > 40000 and toc < 50000 then
+    Lib.gameExpansion = "cata"
+end
 
 -- How long it takes for a DR to expire, in seconds.
 Lib.resetTimes = {
@@ -149,6 +158,10 @@ Lib.resetTimes = {
     },
 
     wotlk = {
+        ["default"] = 20, -- dynamic between 15 and 20s
+        ["npc"] = 21,
+    },
+	cata = {
         ["default"] = 20, -- dynamic between 15 and 20s
         ["npc"] = 21,
     },
@@ -213,6 +226,26 @@ Lib.categoryNames = {
         ["charge"] = L.CHARGE,
         ["opener_stun"] = L.OPENER_STUN,
         ["counterattack"] = L.COUNTERATTACK,
+        ["dragon"] = L.DRAGONS,
+        ["entrapment"] = L.ENTRAPMENT,
+    },
+
+    cata = {
+        ["incapacitate"] = L.INCAPACITATES,
+        ["stun"] = L.STUNS,
+        ["random_stun"] = L.RANDOM_STUNS,
+        ["random_root"] = L.RANDOM_ROOTS,
+        ["root"] = L.ROOTS,
+        ["disarm"] = L.DISARMS,
+        ["fear"] = L.FEARS,
+        ["scatter"] = L.SCATTERS,
+        ["silence"] = L.SILENCES,
+        ["horror"] = L.HORROR,
+        ["mind_control"] = L.MIND_CONTROL,
+        ["cyclone"] = L.CYCLONE,
+        ["counterattack"] = L.COUNTERATTACK,
+        ["dragon"] = L.DRAGONS,
+        ["entrapment"] = L.ENTRAPMENT,
     },
 }
 
@@ -240,6 +273,13 @@ Lib.categoriesPvE = {
         ["random_stun"] = L.RANDOM_STUNS,
         ["opener_stun"] = L.OPENER_STUN,
     },
+
+    cata = {
+        --["taunt"] = L.TAUNTS,
+        ["stun"] = L.STUNS,
+        ["random_stun"] = L.RANDOM_STUNS,
+        ["cyclone"] = L.CYCLONE,
+    },
 }
 
 -- Successives diminished durations
@@ -262,6 +302,10 @@ Lib.diminishedDurations = {
     },
 
     wotlk = {
+        ["default"] = { 0.50, 0.25 },
+    },
+
+    cata = {
         ["default"] = { 0.50, 0.25 },
     },
 }

--- a/DRList-1.0/Spells.lua
+++ b/DRList-1.0/Spells.lua
@@ -588,7 +588,6 @@ elseif Lib.gameExpansion == "wotlk" then
         [55536] = "root", -- Frostweave Net (Item)
 
         -- *** Non-controlled Root Effects ***
-        [19185] = "random_root", -- Entrapment
         [47168] = "random_root", -- Improved Wing Clip
         [12494] = "random_root", -- Frostbite
         [55080] = "random_root", -- Shattered Barrier
@@ -645,12 +644,12 @@ elseif Lib.gameExpansion == "wotlk" then
 
         -- *** Scatter Effects ***
         [19503] = "scatter", -- Scatter Shot
-        [31661] = "scatter", -- Dragon's Breath (Rank 1)
-        [33041] = "scatter", -- Dragon's Breath (Rank 2)
-        [33042] = "scatter", -- Dragon's Breath (Rank 3)
-        [33043] = "scatter", -- Dragon's Breath (Rank 4)
-        [42949] = "scatter", -- Dragon's Breath (Rank 5)
-        [42950] = "scatter", -- Dragon's Breath (Rank 6)
+        [31661] = "dragons", -- Dragon's Breath (Rank 1)
+        [33041] = "dragons", -- Dragon's Breath (Rank 2)
+        [33042] = "dragons", -- Dragon's Breath (Rank 3)
+        [33043] = "dragons", -- Dragon's Breath (Rank 4)
+        [42949] = "dragons", -- Dragon's Breath (Rank 5)
+        [42950] = "dragons", -- Dragon's Breath (Rank 6)
 
         -- *** Spells that DRs with itself only ***
         [33786] = "cyclone",        -- Cyclone
@@ -664,6 +663,188 @@ elseif Lib.gameExpansion == "wotlk" then
         [7922]  = "charge",         -- Charge Stun
         [13181] = "mind_control",   -- Gnomish Mind Control Cap (Item)
         [67799] = "mind_control",   -- Mind Amplification Dish (Item)
+        [19185] = "entrapment", -- Entrapment (Rank 1)
+        [64803] = "entrapment", -- Entrapment (Rank 2)
+    }
+
+elseif Lib.gameExpansion == "cata" then
+
+    ------------------------------------------------
+    -- SpellID list for Cataclysm.
+    ------------------------------------------------
+    Lib.spellList = {
+        -- *** Incapacitate Effects ***
+        [49203] = "incapacitate", -- Hungering Cold
+        [2637]  = "incapacitate", -- Hibernate
+        [3355]  = "incapacitate", -- Freezing Trap Effect
+        [19386] = "incapacitate", -- Wyvern Sting
+        [118]   = "incapacitate", -- Polymorph
+        [28271] = "incapacitate", -- Polymorph: Turtle
+        [28272] = "incapacitate", -- Polymorph: Pig
+        [61025] = "incapacitate", -- Polymorph: Serpent
+        [61721] = "incapacitate", -- Polymorph: Rabbit
+        [61780] = "incapacitate", -- Polymorph: Turkey
+        [61305] = "incapacitate", -- Polymorph: Black Cat
+        [20066] = "incapacitate", -- Repentance
+        [1776]  = "incapacitate", -- Gouge
+        [6770]  = "incapacitate", -- Sap
+        [710]   = "incapacitate", -- Banish
+        [9484]  = "incapacitate", -- Shackle Undead
+        [51514] = "incapacitate", -- Hex
+        [13327] = "incapacitate", -- Reckless Charge (Item)
+        [4064]  = "incapacitate", -- Rough Copper Bomb (Item)
+        [4065]  = "incapacitate", -- Large Copper Bomb (Item)
+        [4066]  = "incapacitate", -- Small Bronze Bomb (Item)
+        [4067]  = "incapacitate", -- Big Bronze Bomb (Item)
+        [4068]  = "incapacitate", -- Iron Grenade (Item)
+        [12421] = "incapacitate", -- Mithril Frag Bomb (Item)
+        [4069]  = "incapacitate", -- Big Iron Bomb (Item)
+        [12562] = "incapacitate", -- The Big One (Item)
+        [12543] = "incapacitate", -- Hi-Explosive Bomb (Item)
+        [19769] = "incapacitate", -- Thorium Grenade (Item)
+        [19784] = "incapacitate", -- Dark Iron Bomb (Item)
+        [30216] = "incapacitate", -- Fel Iron Bomb (Item)
+        [30461] = "incapacitate", -- The Bigger One (Item)
+        [30217] = "incapacitate", -- Adamantite Grenade (Item)
+        [67769] = "incapacitate", -- Cobalt Frag Bomb (Item)
+        [67890] = "incapacitate", -- Cobalt Frag Bomb (Item, Frag Belt)
+        [54466] = "incapacitate", -- Saronite Grenade (Item)
+        [82676] = "incapacitate", -- Ring of Frost
+
+        -- *** Controlled Stun Effects ***
+        [47481] = "stun", -- Gnaw (Ghoul Pet)
+        [5211]  = "stun", -- Bash
+        [22570] = "stun", -- Maim
+        [24394] = "stun", -- Intimidation
+        [50519] = "stun", -- Sonic Blast
+        [50518] = "stun", -- Ravage
+        [44572] = "stun", -- Deep Freeze
+        [853]   = "stun", -- Hammer of Justice
+        [2812]  = "stun", -- Holy Wrath
+        [408]   = "stun", -- Kidney Shot
+        [58861] = "stun", -- Bash (Spirit Wolves)
+        [30283] = "stun", -- Shadowfury
+        [12809] = "stun", -- Concussion Blow
+        [60995] = "stun", -- Demon Charge
+        [30153] = "stun", -- Intercept (Felguard)
+        [20253] = "stun", -- Intercept Stun
+        [46968] = "stun", -- Shockwave
+        [20549] = "stun", -- War Stomp (Racial)
+        [9005]  = "stun", -- Pounce
+        [1833]  = "stun", -- Cheap Shot
+        [85388] = "stun", -- Throwdown
+        [20252] = "stun", -- Intercept
+        [88625] = "stun", -- Holy Word: Chastise
+        [54785] = "stun", -- Demon Leap (Warlock)
+        [22703] = "stun", -- Inferno Effect
+        [56626] = "stun", -- Sting (Wasp)
+        [19577] = "stun", -- Intimidation
+        [93433] = "stun", -- Burrow Attack (Worm)
+        [89766] = "stun", -- Axe Toss (Felguard)
+        [7922]  = "stun", -- Charge Stun
+        [90337] = "stun", -- Bad Manner (Monkey)
+
+        -- *** Non-controlled Stun Effects ***
+        [28445] = "random_stun", -- Improved Concussive Shot
+        [12355] = "random_stun", -- Impact
+        [20170] = "random_stun", -- Seal of Justice Stun
+        [39796] = "random_stun", -- Stoneclaw Stun
+        [12798] = "random_stun", -- Revenge Stun
+        [5530]  = "random_stun", -- Mace Stun Effect (Mace Specialization)
+        [15283] = "random_stun", -- Stunning Blow (Weapon Proc)
+        [56]    = "random_stun", -- Stun (Weapon Proc)
+        [34510] = "random_stun", -- Stormherald/Deep Thunder (Weapon Proc)
+        [11210] = "random_stun", -- Improved Polymorph (Rank 1)
+        [12592] = "random_stun", -- Improved Polymorph (Rank 2)
+
+        -- *** Fear Effects ***
+        [1513]  = "fear", -- Scare Beast
+        [10326] = "fear", -- Turn Evil
+        [8122]  = "fear", -- Psychic Scream
+        [2094]  = "fear", -- Blind
+        [5782]  = "fear", -- Fear
+        [6358]  = "fear", -- Seduction (Succubus)
+        [5484]  = "fear", -- Howl of Terror
+        [5246]  = "fear", -- Intimidating Shout
+        [20511] = "fear", -- Intimidating Shout (secondary targets)
+        [5134]  = "fear", -- Flash Bomb Fear (Item)
+
+        -- *** Controlled Root Effects ***
+        [339]   = "root", -- Entangling Roots
+        [19975] = "root", -- Nature's Grasp
+        [50245] = "root", -- Pin
+        [33395] = "root", -- Freeze (Water Elemental)
+        [122]   = "root", -- Frost Nova
+        [64695] = "root", -- Earthgrab
+        [63685] = "root", -- Freeze (Frost Shock)
+        [39965] = "root", -- Frost Grenade (Item)
+        [55536] = "root", -- Frostweave Net (Item)
+        [90327] = "root", -- Lock Jaw (Dog)
+        [11190] = "root", -- Improved Cone of Cold (Rank 1)
+        [12489] = "root", -- Improved Cone of Cold (Rank 2)
+        [54706] = "root", -- Venom Web Spray (Silithid)
+        [4167]  = "root", -- Web (Spider)
+
+        -- *** Non-controlled Root Effects ***
+        [47168] = "random_root", -- Improved Wing Clip
+        [12494] = "random_root", -- Frostbite
+        [44745] = "random_root", -- Shattered Barrier (Rank 1)
+        [55080] = "random_root", -- Shattered Barrier (2 seconds)
+        [54787] = "random_root", -- Shattered Barrier (Rank 2)
+        [83073] = "random_root", -- Shattered Barrier (4 seconds)
+        [58373] = "random_root", -- Glyph of Hamstring
+        [23694] = "random_root", -- Improved Hamstring
+
+        -- *** Disarm Weapon Effects ***
+        [50541] = "disarm", -- Snatch
+        [64346] = "disarm", -- Fiery Payback
+        [64058] = "disarm", -- Psychic Horror Disarm Effect
+        [51722] = "disarm", -- Dismantle
+        [676]   = "disarm", -- Disarm
+        [91644] = "disarm", -- Snatch (Bird of Prey)
+
+        -- *** Silence Effects ***
+        [47476] = "silence", -- Strangulate
+        [34490] = "silence", -- Silencing Shot
+        [18469] = "silence", -- Silenced - Improved Counterspell (Rank 1)
+        [55021] = "silence", -- Silenced - Improved Counterspell (Rank 2)
+        [63529] = "silence", -- Silenced - Shield of the Templar
+        [15487] = "silence", -- Silence
+        [1330]  = "silence", -- Garrote - Silence
+        [18425] = "silence", -- Silenced - Improved Kick
+        [86759] = "silence", -- Silenced - Improved Kick (Rank 2)
+        [24259] = "silence", -- Spell Lock
+        [31117] = "silence", -- Silenced - Unstable Affliction (Rank 1)
+        [43523] = "silence", -- Silenced - Unstable Affliction (Rank 2)
+        [18498] = "silence", -- Silenced - Gag Order (Shield Slam)
+        [74347] = "silence", -- Silenced - Gag Order (Heroic Throw)
+        [50613] = "silence", -- Arcane Torrent (Racial, Runic Power)
+        [28730] = "silence", -- Arcane Torrent (Racial, Mana)
+        [25046] = "silence", -- Arcane Torrent (Racial, Energy)
+        [69179] = "silence", -- Arcane Torrent (Rage version)
+        [80483] = "silence", -- Arcane Torrent (Focus version)
+        [31935] = "silence", -- Avenger's Shield
+        [81261] = "silence", -- Solar Beam
+        [50479] = "silence", -- Nether Shock (Nether Ray)
+
+        -- *** Horror Effects ***
+        [64044] = "horror", -- Psychic Horror
+        [6789]  = "horror", -- Death Coil
+        [87099] = "horror", -- Sin and Punishment (Rank 1)
+        [87100] = "horror", -- Sin and Punishment (Rank 2)
+
+        -- *** Mind Control Effects ***
+        [605]   = "mind_control",   -- Mind Control
+        [13181] = "mind_control",   -- Gnomish Mind Control Cap (Item)
+        [67799] = "mind_control",   -- Mind Amplification Dish (Item)
+
+        -- *** Spells that DRs with itself only ***
+        [19503] = "scatter",       -- Scatter Shot
+        [31661] = "dragon",        -- Dragon's Breath
+        [33786] = "cyclone",       -- Cyclone
+        [19306] = "counterattack", -- Counterattack
+        [19185] = "entrapment", -- Entrapment (Rank 1)
+        [64803] = "entrapment", -- Entrapment (Rank 2)
     }
 
 elseif Lib.gameExpansion == "classic" then
@@ -808,6 +989,5 @@ elseif Lib.gameExpansion == "classic" then
         [10473]  = "frost_shock",  -- Frost Shock (Rank 4)
     }
 end
-
 -- Alias for DRData-1.0
 Lib.spells = Lib.spellList


### PR DESCRIPTION
Tried to add most / all DRs, and removed the ones that no longer exist.

Some noteworthy stuff:
- Dragon's Breath & Scatter Shot do not share a DR (not in Cata nor in WotLK)
- Entrapment is a separate DR category (only DRs with itself), afaik in both Cata and WotLK
- Most of the removals are R1/R2/R3 things you train at the trainer (which no longer exist in Cata)
- There are still some R1/R2 things, but that's mainly because you can pick 1/2 or 2/2 talents
- Added some new auras (Throwdown, Bad Manner etc)