### PR TITLE
fix: GetSpellInfo removed in WoW 11.0

### DIFF
--- a/DRList-1.0/DRList-1.0.lua
+++ b/DRList-1.0/DRList-1.0.lua
@@ -13,6 +13,8 @@ local MAJOR, MINOR = "DRList-1.0", 66 -- Don't forget to change this in Spells.l
 local Lib = assert(LibStub, MAJOR .. " requires LibStub."):NewLibrary(MAJOR, MINOR)
 if not Lib then return end -- already loaded
 
+local GetSpellName = C_Spell and C_Spell.GetSpellName or GetSpellInfo
+
 Lib.L = {}
 
 -------------------------------------------------------------------------------
@@ -34,16 +36,16 @@ L["OPENER_STUN"] = "Opener stuns"
 L["HORROR"] = "Horrors"
 L["SCATTERS"] = "Scatters"
 L["DEEP_FREEZE_ROF"] = "DF/RoF Shared"
-L["MIND_CONTROL"] = GetSpellInfo(605) or "Mind Control"
-L["FROST_SHOCK"] = GetSpellInfo(15089) or "Frost Shock"
-L["KIDNEY_SHOT"] = GetSpellInfo(408) or "Kidney Shot"
-L["DEATH_COIL"] = GetSpellInfo(28412) or "Death Coil"
-L["UNSTABLE_AFFLICTION"] = GetSpellInfo(31117) or "Unstable Affliction"
-L["CHASTISE"] = GetSpellInfo(44041) or "Chastise"
-L["COUNTERATTACK"] = GetSpellInfo(19306) or "Counterattack"
-L["BIND_ELEMENTAL"] = GetSpellInfo(76780) or "Bind Elemental"
-L["CYCLONE"] = GetSpellInfo(33786) or "Cyclone"
-L["CHARGE"] = GetSpellInfo(100) or "Charge"
+L["MIND_CONTROL"] = GetSpellName(605) or "Mind Control"
+L["FROST_SHOCK"] = GetSpellName(15089) or "Frost Shock"
+L["KIDNEY_SHOT"] = GetSpellName(408) or "Kidney Shot"
+L["DEATH_COIL"] = GetSpellName(28412) or "Death Coil"
+L["UNSTABLE_AFFLICTION"] = GetSpellName(31117) or "Unstable Affliction"
+L["CHASTISE"] = GetSpellName(44041) or "Chastise"
+L["COUNTERATTACK"] = GetSpellName(19306) or "Counterattack"
+L["BIND_ELEMENTAL"] = GetSpellName(76780) or "Bind Elemental"
+L["CYCLONE"] = GetSpellName(33786) or "Cyclone"
+L["CHARGE"] = GetSpellName(100) or "Charge"
 
 -- luacheck: push ignore 542
 local locale = GetLocale()

--- a/DRList-1.0/DRList-1.0.lua
+++ b/DRList-1.0/DRList-1.0.lua
@@ -9,7 +9,7 @@ License: MIT
 
 --- DRList-1.0
 -- @module DRList-1.0
-local MAJOR, MINOR = "DRList-1.0", 66 -- Don't forget to change this in Spells.lua aswell!
+local MAJOR, MINOR = "DRList-1.0", 67 -- Don't forget to change this in Spells.lua aswell!
 local Lib = assert(LibStub, MAJOR .. " requires LibStub."):NewLibrary(MAJOR, MINOR)
 if not Lib then return end -- already loaded
 

--- a/DRList-1.0/DRList-1.0.lua
+++ b/DRList-1.0/DRList-1.0.lua
@@ -13,7 +13,7 @@ local MAJOR, MINOR = "DRList-1.0", 67 -- Don't forget to change this in Spells.l
 local Lib = assert(LibStub, MAJOR .. " requires LibStub."):NewLibrary(MAJOR, MINOR)
 if not Lib then return end -- already loaded
 
-local GetSpellName = C_Spell and C_Spell.GetSpellName or GetSpellInfo
+local GetSpellName = _G.C_Spell and _G.C_Spell.GetSpellName or _G.GetSpellInfo
 
 Lib.L = {}
 

--- a/DRList-1.0/Spells.lua
+++ b/DRList-1.0/Spells.lua
@@ -1,4 +1,4 @@
-local MAJOR, MINOR = "DRList-1.0", 66 -- Don't forget to change this in DRList-1.0.lua aswell!
+local MAJOR, MINOR = "DRList-1.0", 67 -- Don't forget to change this in DRList-1.0.lua aswell!
 local Lib = LibStub(MAJOR)
 if Lib.spellListVersion and Lib.spellListVersion >= MINOR then
     return


### PR DESCRIPTION
GetSpellInfo is removed in TWW. Deprecation fallbacks are currently enabled on the PTR, but disabled in TWW Beta, so this isn't working in beta right now.

https://github.com/Gethe/wow-ui-source/blob/9c7b0f6e8550adb0252faad4bea44d8aad38abc0/Interface/AddOns/Blizzard_Deprecated/Deprecated_11_0_0.lua#L12