### PR TITLE
[Retail] Add Ring of Fire disorient to Spells.lua.

### DIFF
--- a/DRList-1.0/Spells.lua
+++ b/DRList-1.0/Spells.lua
@@ -32,6 +32,7 @@ if Lib.gameExpansion == "retail" then
         [118699]  = "disorient", -- Fear
         [130616]  = "disorient", -- Fear (Horrify)
         [5484]    = "disorient", -- Howl of Terror
+        [353084]  = "disorient", -- Ring of Fire
         [261589]  = "disorient", -- Seduction (Grimoire of Sacrifice)
         [6358]    = "disorient", -- Seduction (Succubus)
         [5246]    = "disorient", -- Intimidating Shout


### PR DESCRIPTION
Hello
Ring of Fire (mage) is now a disorient in retail.
I added it to the list of disorients in Spells.lua.
Best regards